### PR TITLE
Add package name in macro calls.

### DIFF
--- a/macros/dimension.sql
+++ b/macros/dimension.sql
@@ -4,14 +4,14 @@
     payload,
     type2
     ) -%}
-{%- set business_key = business_key_name(name) -%}
+{%- set business_key = versent_automate_dbt_dimensional.business_key_name(name) -%}
 
-{%- set sid = sid_name(name) -%}
+{%- set sid = versent_automate_dbt_dimensional.sid_name(name) -%}
 with 
     source as (
         select
             {{ business_key}},
-            {{ payload_columns(payload)}},
+            {{ versent_automate_dbt_dimensional.payload_columns(payload)}},
             -- hashdiff
                 CAST(UPPER(md5(CONCAT(
                 {%- for col in payload %}
@@ -27,7 +27,7 @@ with
             {% if type2 %}
             {{ type2_columns(business_key, type2) }}
             {% endif %}
-            {{ audit_columns() }}
+            {{ versent_automate_dbt_dimensional.audit_columns() }}
         from 
         {{ ref(source) }}
         where
@@ -40,7 +40,7 @@ with
         select
             md5(concat(
                 {{ business_key }} 
-                {%- if type2 -%}, '|', {{ effective_date_column('from') }} {%- endif%}
+                {%- if type2 -%}, '|', {{ versent_automate_dbt_dimensional.effective_date_column('from') }} {%- endif%}
                  )) as {{sid}},
             {{ business_key }},
             {%- for col in payload %}
@@ -48,8 +48,8 @@ with
             {%- endfor %}
             {%- if type2 -%}
             -- cdc columns
-                {{ effective_date_column('from') }},
-                {{ effective_date_column('to') }},
+                {{ versent_automate_dbt_dimensional.effective_date_column('from') }},
+                {{ versent_automate_dbt_dimensional.effective_date_column('to') }},
                 is_current,
             {%- endif -%}
             -- audit columns

--- a/macros/fact.sql
+++ b/macros/fact.sql
@@ -17,17 +17,17 @@ with
     select
         bridge.{{primary_key}},
         -- Add Type 1 dimension columns (if type 1 dims exist)
-        {{ dimension_columns(type1_dims) }}
+        {{ versent_automate_dbt_dimensional.dimension_columns(type1_dims) }}
         -- Add Type 2 dimension columns (if type 2 dims exist)
-        {{ dimension_columns(type2_dims) }}
-        {{ payload_columns(payload)}},
-        {{ audit_columns('bridge') }}
+        {{ versent_automate_dbt_dimensional.dimension_columns(type2_dims) }}
+        {{ versent_automate_dbt_dimensional.payload_columns(payload)}},
+        {{ versent_automate_dbt_dimensional.audit_columns('bridge') }}
     from
         bridge
         -- join Type 1 Dimensions (if they exist)
-        {{join_dimensions(type1_dims, 'type1')}}                
+        {{versent_automate_dbt_dimensional.join_dimensions(type1_dims, 'type1')}}                
         -- join Type 2 Dimensions (if they exist)
-        {{join_dimensions(type2_dims, 'type2')}}          
+        {{versent_automate_dbt_dimensional.join_dimensions(type2_dims, 'type2')}}          
     
 {%- endmacro %}
 

--- a/macros/support/change_data_capture.sql
+++ b/macros/support/change_data_capture.sql
@@ -6,9 +6,9 @@
             {%- set as_of_date_source = type2.as_of_date %}
             {%- set effective_from = var('effective_from_name', 'effective_from') -%}
             {%- set effective_to = var('effective_to_name', 'effective_to') %}                  
-            {{ effective_from_datetime(business_key, as_of_date_source)}}  as {{ effective_from }},
-            {{ effective_to_datetime(business_key, as_of_date_source)}}  as {{ effective_to }},
-            {{ is_current(business_key, as_of_date_source)}}  as is_current,
+            {{ versent_automate_dbt_dimensional.effective_from_datetime(business_key, as_of_date_source)}}  as {{ effective_from }},
+            {{ versent_automate_dbt_dimensional.effective_to_datetime(business_key, as_of_date_source)}}  as {{ effective_to }},
+            {{ versent_automate_dbt_dimensional.is_current(business_key, as_of_date_source)}}  as is_current,
 
 {%- endmacro %}
 {%- macro early_date() -%}
@@ -50,9 +50,9 @@
     ) -%}
     iff(
     -- previous_date
-        {{ previous_date(business_key, as_of_date_source)}}
+        {{ versent_automate_dbt_dimensional.previous_date(business_key, as_of_date_source)}}
         is null, 
-        {{ early_date() }}, 
+        {{ versent_automate_dbt_dimensional.early_date() }}, 
         as_of_date)
 
 
@@ -63,14 +63,14 @@
     ) -%}
     coalesce(
         -- next_date - 1 very small bit
-            {{ next_date(business_key, as_of_date_source)}} 
+            {{ versent_automate_dbt_dimensional.next_date(business_key, as_of_date_source)}} 
             -- {{ target.type }}
             {% if target.type == "databricks" %}
             - INTERVAL 1 microsecond     
             {% elif target.type == "snowflake" %}          
             - INTERVAL '1 MICROSECONDS'
             {% endif %}, 
-        {{ late_date() }}
+        {{ versent_automate_dbt_dimensional.late_date() }}
         )
 
     {%- endmacro%}
@@ -80,7 +80,7 @@
     ) -%}
     iff(
         -- next_date
-        {{ next_date(business_key, as_of_date_source)}} is null,
+        {{ versent_automate_dbt_dimensional.next_date(business_key, as_of_date_source)}} is null,
         true,
         false
     )    

--- a/models/templates/fact/fact_template.sql
+++ b/models/templates/fact/fact_template.sql
@@ -40,7 +40,7 @@ payload:
 
 {% set metadata_dict = fromyaml(yaml_metadata) %}
 
-{{ fact(
+{{ versent_automate_dbt_dimensional.fact(
     source = metadata_dict['source'],
     name = metadata_dict['name'],
     primary_key = metadata_dict['primary_key'],


### PR DESCRIPTION
Dbt requires explicit package reference when calling macros from installed packages. Without it, we will get a compilation error saying the macro is undefined.

Example: **versent_automate_dbt_dimensional**.business_key_name(name)