### PR TITLE
Added sid_type variable and updated dimesion to use record_source and load_datetime from dbt_project.yml variable.

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -34,7 +34,7 @@ vars:
     include_business_keys: y
   # common
     sid_name: dim_<name>_sid
-    
+    sid_type: binary(16)
     # type 2 behaviour
     effective_from_name: effective_from_timestamp
     effective_to_name: effective_to_timestamp

--- a/macros/dimension.sql
+++ b/macros/dimension.sql
@@ -5,8 +5,9 @@
     type2
     ) -%}
 {%- set business_key = versent_automate_dbt_dimensional.business_key_name(name) -%}
-
 {%- set sid = versent_automate_dbt_dimensional.sid_name(name) -%}
+{%- set sid_type = var('sid_type', 'STRING') %}
+
 with 
     source as (
         select
@@ -38,10 +39,10 @@ with
     ),
     final as (
         select
-            md5(concat(
+            cast(md5(concat(
                 {{ business_key }} 
                 {%- if type2 -%}, '|', {{ versent_automate_dbt_dimensional.effective_date_column('from') }} {%- endif%}
-                 )) as {{sid}},
+                 )) as {{sid_type}}) as {{sid}},
             {{ business_key }},
             {%- for col in payload %}
             {{col}},
@@ -53,8 +54,7 @@ with
                 is_current,
             {%- endif -%}
             -- audit columns
-                '{{source}}'                        as record_source,
-                current_timestamp()                 as load_datetime
+            {{ versent_automate_dbt_dimensional.audit_columns() }}
         from
             source
         where

--- a/macros/support/support.sql
+++ b/macros/support/support.sql
@@ -40,8 +40,8 @@
         {%- if source %}
                 {% set qualifier = source ~ '.' %}
         {%- endif %}
-            {{ qualifier }}record_source,
-            {{ qualifier }}load_datetime
+            {{ qualifier }}{{ var('record_source') }},
+            {{ qualifier }}{{ var('load_datetime') }}
 {%- endmacro %}
 {% macro effective_date_column(
     type


### PR DESCRIPTION
1. Added sid_type det variable and updated the dimension macro to cast the dimension sid to the type set in this variable.
2. Updated audit columns (record_source and load_datetime) to use the names set in the dbt variables.
![image](https://github.com/user-attachments/assets/0faa3761-97f0-4dd0-b310-b4c1bd5958c7)
